### PR TITLE
first stab

### DIFF
--- a/python/lvmsurveysim/ifu.py
+++ b/python/lvmsurveysim/ifu.py
@@ -13,7 +13,7 @@ import matplotlib.patches
 import matplotlib.pyplot
 import numpy
 import astropy.units
-from astropy.coordinates.angle_utilities import position_angle
+from astropy.coordinates import angular_separation
 
 import lvmsurveysim
 from lvmsurveysim import config
@@ -135,7 +135,7 @@ def transform_coords(lat, lon, transform):
     '''
     lat2, lon2 = transform(lat, lon + 1./3600.)
     lat1, lon1 = transform(lat, lon)
-    pa = position_angle(numpy.deg2rad(lat1), numpy.deg2rad(lon1), numpy.deg2rad(lat2), numpy.deg2rad(lon2))
+    pa = angular_separation(numpy.deg2rad(lat1), numpy.deg2rad(lon1), numpy.deg2rad(lat2), numpy.deg2rad(lon2))
     return numpy.array([lat1, lon1]).T, numpy.rad2deg(pa)
 
 
@@ -500,6 +500,8 @@ class IFU(object):
             # The size of the grid in phi and theta, in degrees.
             size_phi  = numpy.abs(maxphi - minphi) * numpy.cos(numpy.radians(centroid[1]))
             size_theta = numpy.abs(maxtheta - mintheta)
+            size_phi = size_phi[0]
+            size_theta = size_theta[0]
 
             # The separation between grid points in angles (phi ~ RA/lon, theta ~ DEC/lat)
             delta_phi = ifu_phi_size*2.0

--- a/python/lvmsurveysim/schedule/tiledb.py
+++ b/python/lvmsurveysim/schedule/tiledb.py
@@ -280,7 +280,7 @@ class TileDB(object):
         # All the coordinates and position angles
         ra = numpy.concatenate([[t.coords.ra.deg for t in self.tiles[idx]] for idx in s])
         dec = numpy.concatenate([[t.coords.dec.deg for t in self.tiles[idx]] for idx in s])
-        tile_pa = numpy.concatenate([[t.pa.deg for t in self.tiles[idx]] for idx in s])
+        tile_pa = numpy.concatenate([[t.pa for t in self.tiles[idx]] for idx in s])
 
         # Create an array of the target's priority for each pointing
         target_prio = numpy.concatenate([numpy.repeat(self.targets[idx].priority, len(self.tiles[idx])) for idx in s])

--- a/python/lvmsurveysim/target/target.py
+++ b/python/lvmsurveysim/target/target.py
@@ -285,7 +285,7 @@ class Target(object):
                                        tile_overlap=self.tile_overlap, sparse=self.sparse, geodesic=self.geodesic)
         # convert to skycoords and optionally transform in to the requested frame, most likely 'icrs'
         tiles, pa2 = self.transform_skycoords(coords[:, 0], coords[:, 1], unit='deg', to_frame=to_frame)
-        self.pa = pa + pa2
+        self.pa = pa + pa2.value
 
         # cache the new tiles and the priorities
         self.tiles = tiles


### PR DESCRIPTION
Moving to the updated `from astropy.coordinates import angular_separation` had some downstream effects. Some array quantities that needed to be treated as scalars, some units being dropped. The units makes me a little nervous, but it definitely looks like degrees everywhere I ignored them?

This is the type of thing I expect for code that hasn't been touched in 3-4 years, which is 2-3 full astropy versions ago and probably pre numpy 2.0. 